### PR TITLE
test: add unit and integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^4.7.0",
@@ -15,9 +16,13 @@
     "swiper": "^10.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.6",
+    "@testing-library/react": "^14.1.2",
     "autoprefixer": "^10.4.14",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",
-    "vite": "^4.5.0"
+    "vite": "^4.5.0",
+    "vitest": "^1.3.1"
   }
 }

--- a/src/__tests__/integration.test.jsx
+++ b/src/__tests__/integration.test.jsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { SliderProvider, useSliderContext } from '../context/SliderContext.jsx';
+
+vi.mock('../utils/persistence', () => ({
+  default: { loadState: vi.fn(() => null), saveState: vi.fn() },
+  createDebouncedSave: (fn) => fn
+}));
+
+global.fetch = vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ slides: [{ title: 'A' }, { title: 'B' }] }) }));
+
+describe('Slider integration', () => {
+  it('allows navigation and settings update', async () => {
+    const Child = () => {
+      const { currentSlide, setCurrentSlide, settings, updateSettings } = useSliderContext();
+      return (
+        <div>
+          <span data-testid="slide">{currentSlide}</span>
+          <span data-testid="autoplay">{String(settings.autoplay.enabled)}</span>
+          <button onClick={() => setCurrentSlide(1)}>next</button>
+          <button onClick={() => updateSettings({ autoplay: { ...settings.autoplay, enabled: false } })}>toggle</button>
+        </div>
+      );
+    };
+
+    render(<SliderProvider><Child /></SliderProvider>);
+    screen.getByText('next').click();
+    expect(screen.getByTestId('slide').textContent).toBe('1');
+    screen.getByText('toggle').click();
+    expect(screen.getByTestId('autoplay').textContent).toBe('false');
+  });
+});

--- a/src/components/__tests__/NavigationControls.test.jsx
+++ b/src/components/__tests__/NavigationControls.test.jsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('../context/SliderContext', () => ({
+  useSliderContext: () => ({
+    slides: [1,2,3],
+    currentSlide: 0,
+    settings: { autoplay: { enabled: true } },
+    updateSettings: vi.fn()
+  })
+}));
+
+import NavigationControls from '../NavigationControls.jsx';
+
+describe('NavigationControls', () => {
+  const makeSwiper = () => ({
+    swiper: {
+      slidePrev: vi.fn(),
+      slideNext: vi.fn(),
+      slideTo: vi.fn(),
+      autoplay: { start: vi.fn(), stop: vi.fn() }
+    }
+  });
+
+  it('handles arrow navigation and pagination', () => {
+    const ref = { current: makeSwiper() };
+    const { getByLabelText } = render(<NavigationControls swiperRef={ref} />);
+    fireEvent.click(getByLabelText('Previous slide'));
+    fireEvent.click(getByLabelText('Next slide'));
+    fireEvent.click(getByLabelText('Go to slide 2'));
+    expect(ref.current.swiper.slidePrev).toHaveBeenCalled();
+    expect(ref.current.swiper.slideNext).toHaveBeenCalled();
+    expect(ref.current.swiper.slideTo).toHaveBeenCalledWith(1);
+  });
+
+  it('toggles autoplay', () => {
+    const context = require('../context/SliderContext').useSliderContext();
+    const ref = { current: makeSwiper() };
+    const { getByLabelText } = render(<NavigationControls swiperRef={ref} />);
+    fireEvent.click(getByLabelText('Pause autoplay'));
+    expect(context.updateSettings).toHaveBeenCalled();
+    expect(ref.current.swiper.autoplay.stop).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/SlideRenderer.test.jsx
+++ b/src/components/__tests__/SlideRenderer.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const VideoMock = vi.fn((props) => <div data-testid="video" {...props} />);
+const ContentLayerMock = vi.fn(({ onElementReady, layerIndex }) => {
+  onElementReady(`el-${layerIndex}`, layerIndex);
+  return <div data-testid={`layer-${layerIndex}`} />;
+});
+const MultiLayerMock = vi.fn((props) => <div data-testid="multi" {...props} />);
+const LayerAnimMock = vi.fn(() => null);
+
+vi.mock('../VideoBackground', () => ({ default: VideoMock }));
+vi.mock('../ContentLayer', () => ({ default: ContentLayerMock }));
+vi.mock('../MultiLayerAnimations', () => ({ default: MultiLayerMock }));
+vi.mock('../LayerAnimations', () => ({ default: LayerAnimMock }));
+
+import SlideRenderer from '../SlideRenderer.jsx';
+
+describe('SlideRenderer', () => {
+  it('renders image slide and calls onSlideReady', () => {
+    const onReady = vi.fn();
+    render(<SlideRenderer slide={{ image: 'img.jpg' }} index={0} isActive={false} onSlideReady={onReady} />);
+    expect(VideoMock).not.toHaveBeenCalled();
+    expect(onReady).toHaveBeenCalled();
+    expect(LayerAnimMock).toHaveBeenCalled();
+  });
+
+  it('handles video slide waiting for video', () => {
+    const onReady = vi.fn();
+    const { rerender } = render(<SlideRenderer slide={{ video: 'v.mp4' }} index={0} isActive={false} onSlideReady={onReady} />);
+    expect(onReady).not.toHaveBeenCalled();
+    VideoMock.mock.calls[0][0].onVideoReady();
+    rerender(<SlideRenderer slide={{ video: 'v.mp4' }} index={0} isActive={false} onSlideReady={onReady} />);
+    expect(onReady).toHaveBeenCalled();
+  });
+
+  it('registers layer elements for multi-layer slide', () => {
+    render(<SlideRenderer slide={{ layers: [{}, {}] }} index={0} isActive={false} />);
+    expect(ContentLayerMock).toHaveBeenCalledTimes(2);
+    expect(MultiLayerMock).toHaveBeenCalled();
+    const layerElements = MultiLayerMock.mock.calls[0][0].layerElements;
+    expect(layerElements.get(0)).toBe('el-0');
+    expect(layerElements.get(1)).toBe('el-1');
+  });
+});

--- a/src/components/__tests__/SliderSettings.test.jsx
+++ b/src/components/__tests__/SliderSettings.test.jsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const updateSettings = vi.fn();
+vi.mock('../context/SliderContext', () => ({
+  useSliderContext: () => ({
+    settings: { autoplay: { enabled: true, delay: 5000 }, navigation: { enabled: true, arrows: true, pagination: true } },
+    updateSettings
+  })
+}));
+
+import SliderSettings from '../SliderSettings.jsx';
+
+describe('SliderSettings', () => {
+  it('updates nested settings and applies', () => {
+    const { getByLabelText, getByText } = render(<SliderSettings isOpen={true} onClose={() => {}} />);
+    fireEvent.click(getByLabelText('Enable Autoplay'));
+    fireEvent.click(getByLabelText('Enable Navigation'));
+    fireEvent.click(getByText('Apply'));
+    expect(updateSettings).toHaveBeenCalledWith(expect.objectContaining({ autoplay: { enabled: false, delay: 5000 }, navigation: { enabled: false, arrows: true, pagination: true } }));
+  });
+
+  it('resets to defaults', () => {
+    const { getByText } = render(<SliderSettings isOpen={true} onClose={() => {}} />);
+    fireEvent.click(getByText('Reset'));
+    fireEvent.click(getByText('Apply'));
+    expect(updateSettings).toHaveBeenCalledWith(expect.objectContaining({ autoplay: { enabled: true, delay: 5000 }, navigation: { enabled: true, arrows: true, pagination: true }, loop: true }));
+  });
+});

--- a/src/components/__tests__/VideoBackground.test.jsx
+++ b/src/components/__tests__/VideoBackground.test.jsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import VideoBackground from '../VideoBackground.jsx';
+
+describe('VideoBackground', () => {
+  it('plays and pauses based on isActive', async () => {
+    vi.spyOn(global.HTMLMediaElement.prototype, 'play').mockResolvedValue();
+    vi.spyOn(global.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+    const { container, rerender } = render(<VideoBackground videoSrc="v.mp4" isActive={true} />);
+    const video = container.querySelector('video');
+    fireEvent.loadedData(video);
+    await Promise.resolve();
+    expect(global.HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    rerender(<VideoBackground videoSrc="v.mp4" isActive={false} />);
+    fireEvent.loadedData(container.querySelector('video'));
+    expect(global.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+  });
+
+  it('falls back to poster image on error', () => {
+    const { container } = render(<VideoBackground videoSrc="v.mp4" posterImage="p.jpg" />);
+    const video = container.querySelector('video');
+    fireEvent.error(video, { target: { error: new Error('err') } });
+    expect(container.querySelector('video')).toBeNull();
+    const div = container.querySelector('div');
+    expect(div.style.backgroundImage).toContain('p.jpg');
+  });
+});

--- a/src/components/__tests__/VideoControls.test.jsx
+++ b/src/components/__tests__/VideoControls.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React, { createRef } from 'react';
+import VideoControls from '../VideoControls.jsx';
+
+describe('VideoControls', () => {
+  const setup = () => {
+    const video = {
+      paused: true,
+      muted: true,
+      play: vi.fn().mockResolvedValue(),
+      pause: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn()
+    };
+    const ref = { current: video };
+    return { ref, video };
+  };
+
+  it('toggles play/pause', async () => {
+    const { ref, video } = setup();
+    const { getByLabelText } = render(<VideoControls videoRef={ref} showControls={true} autoHide={false} />);
+    fireEvent.click(getByLabelText('Play video'));
+    expect(video.play).toHaveBeenCalled();
+    video.paused = false;
+    fireEvent.click(getByLabelText('Pause video'));
+    expect(video.pause).toHaveBeenCalled();
+  });
+
+  it('toggles mute', () => {
+    const { ref, video } = setup();
+    const { getByLabelText } = render(<VideoControls videoRef={ref} showControls={true} autoHide={false} />);
+    fireEvent.click(getByLabelText('Unmute video'));
+    expect(video.muted).toBe(false);
+    fireEvent.click(getByLabelText('Mute video'));
+    expect(video.muted).toBe(true);
+  });
+
+  it('auto hides controls', () => {
+    vi.useFakeTimers();
+    const { ref } = setup();
+    const { container } = render(<VideoControls videoRef={ref} showControls={true} autoHide={true} />);
+    expect(container.firstChild).not.toBeNull();
+    vi.advanceTimersByTime(3000);
+    expect(container.firstChild).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/src/context/__tests__/SliderContext.test.jsx
+++ b/src/context/__tests__/SliderContext.test.jsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { SliderProvider, useSliderContext } from '../SliderContext.jsx';
+
+vi.mock('../../utils/persistence', () => {
+  const loadState = vi.fn(() => ({
+    currentSlide: 1,
+    settings: { autoplay: { delay: 1000, enabled: false }, loop: false }
+  }));
+  const saveState = vi.fn();
+  return {
+    default: { loadState, saveState },
+    sliderPersistence: { loadState, saveState },
+    createDebouncedSave: (fn) => fn
+  };
+});
+
+const TestComponent = () => {
+  const { settings, currentSlide, updateSettings, addEventListener, dispatchEvent, setCurrentSlide } = useSliderContext();
+  return (
+    <div>
+      <span data-testid="delay">{settings.autoplay.delay}</span>
+      <span data-testid="enabled">{String(settings.autoplay.enabled)}</span>
+      <span data-testid="current">{currentSlide}</span>
+      <button onClick={() => updateSettings({ autoplay: { delay: 2000 } })}>update</button>
+      <button onClick={() => {
+        const cb = vi.fn();
+        addEventListener('custom', cb);
+        dispatchEvent('custom', { foo: 'bar' });
+        dispatchEvent('custom', { foo: 'baz' });
+        cb.mock.calls.forEach(call => { document.body.append(JSON.stringify(call[0])); });
+      }}>dispatch</button>
+      <button onClick={() => setCurrentSlide(2)}>slide</button>
+    </div>
+  );
+};
+
+describe('SliderContext', () => {
+  it('merges persisted settings and updates them', () => {
+    render(<SliderProvider><TestComponent /></SliderProvider>);
+    expect(screen.getByTestId('delay').textContent).toBe('1000');
+    expect(screen.getByTestId('enabled').textContent).toBe('false');
+    screen.getByText('update').click();
+    expect(screen.getByTestId('delay').textContent).toBe('2000');
+  });
+
+  it('handles events and slide change events', () => {
+    vi.useFakeTimers();
+    const beforeFn = vi.fn();
+    const afterFn = vi.fn();
+
+    const Wrapper = () => {
+      const { addEventListener, setCurrentSlide } = useSliderContext();
+      addEventListener('beforeSlideChange', beforeFn);
+      addEventListener('slideChange', afterFn);
+      return <button onClick={() => setCurrentSlide(3)}>go</button>;
+    };
+
+    render(<SliderProvider><Wrapper /></SliderProvider>);
+    screen.getByText('go').click();
+    expect(beforeFn).toHaveBeenCalledWith(expect.objectContaining({ from: 1, to: 3 }));
+    vi.runAllTimers();
+    expect(afterFn).toHaveBeenCalledWith(expect.objectContaining({ from: 1, to: 3 }));
+    vi.useRealTimers();
+  });
+});

--- a/src/utils/__tests__/animations.test.js
+++ b/src/utils/__tests__/animations.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('gsap', () => ({
+  gsap: {
+    set: vi.fn(),
+    to: vi.fn(() => ({ kill: vi.fn() })),
+    timeline: vi.fn(() => ({ kill: vi.fn() })),
+    killTweensOf: vi.fn()
+  }
+}));
+import { AnimationManager, globalAnimationManager, animationUtils } from '../animations.js';
+
+const gsap = (await import('gsap')).gsap;
+
+describe('AnimationManager', () => {
+  let manager;
+  beforeEach(() => {
+    manager = new AnimationManager();
+  });
+
+  it('executes preset and tracks timeline', () => {
+    const el = {};
+    manager.executePreset(el, 'fadeIn');
+    expect(gsap.set).toHaveBeenCalled();
+    expect(gsap.to).toHaveBeenCalled();
+    expect(manager.timelines.size).toBe(1);
+  });
+
+  it('creates timeline and kills all', () => {
+    const tl = manager.createTimeline();
+    expect(gsap.timeline).toHaveBeenCalled();
+    expect(manager.timelines.has(tl)).toBe(true);
+    manager.killAll();
+    expect(manager.timelines.size).toBe(0);
+  });
+});
+
+describe('animationUtils', () => {
+  it('staggerElements calls executePreset with delays', () => {
+    const spy = vi.spyOn(globalAnimationManager, 'executePreset');
+    animationUtils.staggerElements(['a', 'b', 'c'], 'fadeIn', 0.2);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy.mock.calls[1][1]).toBe('fadeIn');
+    spy.mockRestore();
+  });
+});

--- a/src/utils/__tests__/persistence.test.js
+++ b/src/utils/__tests__/persistence.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sliderPersistence, createDebouncedSave } from '../persistence';
+
+describe('sliderPersistence', () => {
+  let store;
+
+  beforeEach(() => {
+    store = {};
+    global.localStorage = {
+      getItem: vi.fn(key => store[key] || null),
+      setItem: vi.fn((key, value) => { store[key] = value; }),
+      removeItem: vi.fn(key => { delete store[key]; })
+    };
+    vi.spyOn(Date, 'now').mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('saves and loads state', () => {
+    sliderPersistence.saveState({ currentSlide: 2, settings: { foo: 'bar' } });
+    const result = sliderPersistence.loadState();
+    expect(localStorage.setItem).toHaveBeenCalled();
+    expect(result).toEqual({ currentSlide: 2, settings: { foo: 'bar' } });
+  });
+
+  it('expires state after 24h', () => {
+    sliderPersistence.saveState({ currentSlide: 1, settings: {} });
+    vi.spyOn(Date, 'now').mockReturnValue(25 * 60 * 60 * 1000);
+    const result = sliderPersistence.loadState();
+    expect(result).toBeNull();
+  });
+
+  it('clears state', () => {
+    sliderPersistence.saveState({ currentSlide: 1, settings: {} });
+    sliderPersistence.clearState();
+    expect(localStorage.removeItem).toHaveBeenCalled();
+  });
+
+  it('detects availability', () => {
+    expect(sliderPersistence.isAvailable()).toBe(true);
+  });
+});
+
+describe('createDebouncedSave', () => {
+  it('debounces calls', () => {
+    vi.useFakeTimers();
+    const saveFn = vi.fn();
+    const debounced = createDebouncedSave(saveFn, 1000);
+    debounced({ a: 1 });
+    debounced({ a: 2 });
+    vi.advanceTimersByTime(1000);
+    expect(saveFn).toHaveBeenCalledTimes(1);
+    expect(saveFn).toHaveBeenCalledWith({ a: 2 });
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest and testing-library dependencies
- cover persistence utilities, context, components and animations with unit tests
- add basic integration test for slider state interactions

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689363e1b6c0832bb382376b87e620f9